### PR TITLE
Grab IMU values from IMU_OUTPUT instead of ROS_IMU, populate covariance from ROS_IMU when available from satellite

### DIFF
--- a/fusion-engine-driver/CMakeLists.txt
+++ b/fusion-engine-driver/CMakeLists.txt
@@ -17,7 +17,7 @@ set(P1_FE_BUILD_EXAMPLES OFF)
 include(FetchContent)
 FetchContent_Declare(
     fusion_engine_client
-    GIT_REPOSITORY https://github.com/PointOneNav/fusion-engine-client.git
+    GIT_REPOSITORY git@github.com:airacingtech/fusion-engine-client.git
     GIT_TAG origin/master
 )
 FetchContent_Populate(fusion_engine_client)

--- a/fusion-engine-driver/core/fusion_engine_interface.cc
+++ b/fusion-engine-driver/core/fusion_engine_interface.cc
@@ -39,18 +39,21 @@ void FusionEngineInterface::initialize(rclcpp::Node* node,
 void FusionEngineInterface::messageReceived(const MessageHeader& header,
                                             const void* payload_in) {
   auto payload = static_cast<const uint8_t*>(payload_in);
-
-  if (header.message_type == MessageType::ROS_IMU) {
-    printf("[ROS_IMU] Payload (%u bytes):\n", header.payload_size_bytes);
-    for (uint32_t i = 0; i < header.payload_size_bytes; i++) {
-      printf("%02X ", payload[i]);
-      if ((i + 1) % 8 == 0) printf("\n");  // pretty formatting
-    }
-    printf("\n");
-  }
+  //dumpHex(header, payload);
   publisher(header, payload);
 }
 
+/******************************************************************************/
+void FusionEngineInterface::dumpHex(const MessageHeader& header, const uint8_t* payload) {
+  if (header.message_type == MessageType::ROS_IMU) {
+	  printf("[ROS_IMU] Payload (%u bytes):\n", header.payload_size_bytes);
+	  for (uint32_t i = 0; i < header.payload_size_bytes; i++) {
+		  printf("%02X ", payload[i]);
+		  if ((i + 1) % 8 == 0) printf("\n");  // 8 Bytes, according to PON Manual.
+	  }
+	  printf("\n");
+  }
+}
 /******************************************************************************/
 void FusionEngineInterface::decodeFusionEngineMessage(uint8_t* frame,
                                                       size_t bytes_read) {

--- a/fusion-engine-driver/core/fusion_engine_interface.cc
+++ b/fusion-engine-driver/core/fusion_engine_interface.cc
@@ -45,14 +45,14 @@ void FusionEngineInterface::messageReceived(const MessageHeader& header,
 
 /******************************************************************************/
 void FusionEngineInterface::dumpHex(const MessageHeader& header, const uint8_t* payload) {
-  if (header.message_type == MessageType::ROS_IMU) {
-	  printf("[ROS_IMU] Payload (%u bytes):\n", header.payload_size_bytes);
-	  for (uint32_t i = 0; i < header.payload_size_bytes; i++) {
-		  printf("%02X ", payload[i]);
-		  if ((i + 1) % 8 == 0) printf("\n");  // 8 Bytes, according to PON Manual.
-	  }
-	  printf("\n");
-  }
+	if (header.message_type == MessageType::ROS_IMU) {
+		printf("[ROS_IMU] Payload (%u bytes):\n", header.payload_size_bytes);
+		for (uint32_t i = 0; i < header.payload_size_bytes; i++) {
+			printf("%02X ", payload[i]);
+			if ((i + 1) % 8 == 0) printf("\n");  // 8 Bytes, according to PON Manual.
+		}
+		printf("\n");
+	}
 }
 /******************************************************************************/
 void FusionEngineInterface::decodeFusionEngineMessage(uint8_t* frame,

--- a/fusion-engine-driver/core/fusion_engine_interface.cc
+++ b/fusion-engine-driver/core/fusion_engine_interface.cc
@@ -40,6 +40,14 @@ void FusionEngineInterface::messageReceived(const MessageHeader& header,
                                             const void* payload_in) {
   auto payload = static_cast<const uint8_t*>(payload_in);
 
+  if (header.message_type == MessageType::ROS_IMU) {
+    printf("[ROS_IMU] Payload (%u bytes):\n", header.payload_size_bytes);
+    for (uint32_t i = 0; i < header.payload_size_bytes; i++) {
+      printf("%02X ", payload[i]);
+      if ((i + 1) % 8 == 0) printf("\n");  // pretty formatting
+    }
+    printf("\n");
+  }
   publisher(header, payload);
 }
 

--- a/fusion-engine-driver/core/fusion_engine_interface.hpp
+++ b/fusion-engine-driver/core/fusion_engine_interface.hpp
@@ -72,6 +72,11 @@ class FusionEngineInterface {
   void messageReceived(const MessageHeader& header, const void* payload_in);
 
   /**
+   * Helper function for dumping raw tcp hex values
+   */
+  void dumpHex(const MessageHeader& header, const uint8_t* payload);
+
+  /**
    * @brief Call fusion engine decoder.
    *
    * @param frame Message content.

--- a/fusion-engine-driver/core/fusion_engine_interface.hpp
+++ b/fusion-engine-driver/core/fusion_engine_interface.hpp
@@ -19,6 +19,13 @@ using namespace point_one::fusion_engine::messages;
 using namespace point_one::fusion_engine::messages::ros;
 
 /**
+ * For payload information and byte ordering, please reference:
+ * https://pointonenav.com/wp-content/uploads/2025/08/FusionEngine-Message-Specification-0.23.pdf
+ * 
+ * As of 9/1/2025, ROS_IMU payload outputs garbage.
+*/
+
+/**
  * @brief Reads bit stream from the Point One Nav Atlas and notifies all event
  * listeners attached to this object once a complete message has
  * been received according to the good type of reveiver manage in this

--- a/fusion-engine-driver/core/fusion_engine_node.cc
+++ b/fusion-engine-driver/core/fusion_engine_node.cc
@@ -105,7 +105,6 @@ void FusionEngineNode::receivedFusionEngineMessage(const MessageHeader &header,
   } else if (header.message_type == MessageType::ROS_IMU)  {
     ros_imu_ = *reinterpret_cast<
 	    const point_one::fusion_engine::messages::ros::IMUMessage *>(payload);
-     
     /* Per the ROS IMU message specification:
       * - If the a value is known but its covariance is not, its covariance matrix
       *   will be set to 0.0

--- a/fusion-engine-driver/core/fusion_engine_node.cc
+++ b/fusion-engine-driver/core/fusion_engine_node.cc
@@ -85,7 +85,7 @@ void FusionEngineNode::receivedFusionEngineMessage(const MessageHeader &header,
     publishNavFixMsg(gps_fix);
   } else if (header.message_type == MessageType::IMU_OUTPUT) {
     auto &contents = *reinterpret_cast<
-	const point_one::fusion_engine::messages::IMUOutput*>(payload); 	
+	const point_one::fusion_engine::messages::IMUOutput*>(payload);
     sensor_msgs::msg::Imu imu = ConversionUtils::toImu(contents);
     imu.header.frame_id = frame_id_;
     imu.header.stamp = time;
@@ -116,9 +116,10 @@ void FusionEngineNode::receivedFusionEngineMessage(const MessageHeader &header,
       */
     auto sanitize_cov = [](double (&cov)[9]) {
 	    std::replace_if(std::begin(cov), std::end(cov),
-                  [](double v){ return std::isnan(v); },
-                  -1.0);
+			    [](double v){ return std::isnan(v) || v == -1.0; },
+			    std::numeric_limits<double>::quiet_NaN());
     };
+
     sanitize_cov(ros_imu_.orientation_covariance);
     sanitize_cov(ros_imu_.angular_velocity_covariance);
     sanitize_cov(ros_imu_.acceleration_covariance);

--- a/fusion-engine-driver/core/fusion_engine_node.cc
+++ b/fusion-engine-driver/core/fusion_engine_node.cc
@@ -105,23 +105,6 @@ void FusionEngineNode::receivedFusionEngineMessage(const MessageHeader &header,
   } else if (header.message_type == MessageType::ROS_IMU)  {
     ros_imu_ = *reinterpret_cast<
 	    const point_one::fusion_engine::messages::ros::IMUMessage *>(payload);
-    /* Per the ROS IMU message specification:
-      * - If the a value is known but its covariance is not, its covariance matrix
-      *   will be set to 0.0
-      * - If a value is not known or not available, its covariance matrix will be set
-      *   to -1.0
-      *   - The value itself will be set to `NAN`, as this is not specified in the
-      *   ROS message definition
-      */
-    auto sanitize_cov = [](double (&cov)[9]) {
-	    std::replace_if(std::begin(cov), std::end(cov),
-			    [](double v){ return std::isnan(v) || v == -1.0; },
-			    std::numeric_limits<double>::quiet_NaN());
-    };
-
-    sanitize_cov(ros_imu_.orientation_covariance);
-    sanitize_cov(ros_imu_.angular_velocity_covariance);
-    sanitize_cov(ros_imu_.acceleration_covariance);
   } else if (header.message_type == MessageType::ROS_POSE) {	  
     auto &contents = *reinterpret_cast<
         const point_one::fusion_engine::messages::ros::PoseMessage *>(payload);

--- a/fusion-engine-driver/core/fusion_engine_node.hpp
+++ b/fusion-engine-driver/core/fusion_engine_node.hpp
@@ -118,7 +118,7 @@ class FusionEngineNode : public rclcpp::Node {
    */
   rclcpp::TimerBase::SharedPtr timer_;
   /**
-   * @brief Number of sallite used for GNSS.
+   * @brief Number of satellite used for GNSS.
    */
 
   uint8_t satellite_used_;

--- a/fusion-engine-driver/core/fusion_engine_node.hpp
+++ b/fusion-engine-driver/core/fusion_engine_node.hpp
@@ -117,11 +117,22 @@ class FusionEngineNode : public rclcpp::Node {
    * callbacks.
    */
   rclcpp::TimerBase::SharedPtr timer_;
+  /**
+   * @brief Number of sallite used for GNSS.
+   */
+
+  uint8_t satellite_used_;
 
   /**
    * @brief Number of satellite used for create nmea message.
    */
   uint16_t satellite_nb_;
+
+  /**
+   * @brief ROS wrapper for IMU message.
+   * As of 09/01/2025, we are only using this to extract the covariance
+   */
+  IMUMessage ros_imu_;
 
   /**
    * @brief Id of the frame send in ros.

--- a/fusion-engine-driver/params/fusion_engine_driver.param.yaml
+++ b/fusion-engine-driver/params/fusion_engine_driver.param.yaml
@@ -5,3 +5,4 @@
     connection_type: "tcp"
     tcp_ip: "10.42.7.211"
     tcp_port: 30201
+    frame_id: "cg"

--- a/fusion-engine-driver/transport/tcp_listener.hpp
+++ b/fusion-engine-driver/transport/tcp_listener.hpp
@@ -44,7 +44,6 @@ class TcpListener : public DataListener {
    * @brief Listens for incoming data.
    */
   void listen();
-
   /**
    * @brief Writes data to the TCP connection.
    *

--- a/fusion-engine-driver/utils/conversion_utils.hpp
+++ b/fusion-engine-driver/utils/conversion_utils.hpp
@@ -34,9 +34,7 @@ class ConversionUtils {
     gps_fix.pitch = contents.pitch_deg;
     gps_fix.roll = contents.roll_deg;
     gps_fix.dip = contents.dip_deg;
-    gps_fix.time =
-        0;  // contents.p1_time.seconds + (contents.p1_time.fraction_ns * 1e-9);
-            // // time since power-on
+   // gps_fix.time =  contents.p1_time.seconds + (contents.p1_time.fraction_ns * 1e-9); // time since power-on
     gps_fix.gdop = contents.gdop;
     gps_fix.hdop = contents.hdop;
     gps_fix.vdop = contents.vdop;
@@ -63,27 +61,33 @@ class ConversionUtils {
    * @return ROS standard message - Imu;
    */
   static sensor_msgs::msg::Imu toImu(
-      const point_one::fusion_engine::messages::ros::IMUMessage& contents) {
+      const point_one::fusion_engine::messages::IMUOutput& contents) {
     sensor_msgs::msg::Imu imu;
-    imu.orientation.x = contents.orientation[0];
+    /*imu.orientation.x = contents.orientation[0];
     imu.orientation.y = contents.orientation[1];
     imu.orientation.z = contents.orientation[2];
     imu.orientation.w = contents.orientation[3];
+
     std::copy(std::begin(contents.orientation_covariance),
               std::end(contents.orientation_covariance),
               std::begin(imu.orientation_covariance));
-    imu.angular_velocity.x = contents.angular_velocity_rps[0];
-    imu.angular_velocity.y = contents.angular_velocity_rps[1];
-    imu.angular_velocity.z = contents.angular_velocity_rps[2];
-    std::copy(std::begin(contents.angular_velocity_rps),
-              std::end(contents.angular_velocity_rps),
+	      */
+    imu.angular_velocity.x = contents.gyro_rps[0];
+    imu.angular_velocity.y = contents.gyro_rps[1];
+    imu.angular_velocity.z = contents.gyro_rps[2];
+    /*
+    std::copy(std::begin(contents.angular_velocity_covariance),
+              std::end(contents.angular_velocity_covariance),
               std::begin(imu.angular_velocity_covariance));
-    imu.linear_acceleration.x = contents.acceleration_mps2[0];
-    imu.linear_acceleration.y = contents.acceleration_mps2[1];
-    imu.linear_acceleration.z = contents.acceleration_mps2[2];
+	      */
+    imu.linear_acceleration.x = contents.accel_mps2[0];
+    imu.linear_acceleration.y = contents.accel_mps2[1];
+    imu.linear_acceleration.z = contents.accel_mps2[2];
+    /*
     std::copy(std::begin(contents.acceleration_covariance),
               std::end(contents.acceleration_covariance),
               std::begin(imu.linear_acceleration_covariance));
+	      */
     return imu;
   }
 


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the Fusion Engine ROS driver, mainly focused on IMU message handling, GNSS information, and configuration flexibility. The changes improve compatibility with updated message types, enhance debugging capabilities, and ensure more robust parameter management.

**IMU and GNSS message handling:**

* Updated IMU message processing to use `IMU_OUTPUT` instead of `ROS_IMU`, and refactored the conversion utility to match the new message structure. Covariance matrices from the ROS IMU message are now sanitized for NaN values and copied into outgoing messages, improving data integrity. [[1]](diffhunk://#diff-fd40b079ab509b9e6781c373922be0d45fcff3bdd003ae33a27702414125111dR82-R124) [[2]](diffhunk://#diff-7ab85002d25210eeddf85d3db1a3fe188f8b50795ad76f19561767aa352af1f7L66-R90)
* GNSS satellite usage tracking is improved: the number of satellites used is now extracted from the GNSS info message and published in the GPSFix message, making satellite information more accurate and visible. [[1]](diffhunk://#diff-fd40b079ab509b9e6781c373922be0d45fcff3bdd003ae33a27702414125111dR185) [[2]](diffhunk://#diff-fd40b079ab509b9e6781c373922be0d45fcff3bdd003ae33a27702414125111dR82-R124) [[3]](diffhunk://#diff-bb943f9cff89c75c522d806b6ac83177ac09cfb0060a91abdb26aa4566e5dcdcR120-R136)

**Configuration and parameter management:**

* The `frame_id` parameter is now configurable and defaults to `"cg"` instead of an empty string, both in code and in the YAML configuration, ensuring consistent frame assignment across published messages. [[1]](diffhunk://#diff-fd40b079ab509b9e6781c373922be0d45fcff3bdd003ae33a27702414125111dL15-R16) [[2]](diffhunk://#diff-cb6c0d5223cfc2084056e0df219e76f75fd2a3c92dbff995e0458603e49bfe2dR8) [[3]](diffhunk://#diff-fd40b079ab509b9e6781c373922be0d45fcff3bdd003ae33a27702414125111dL97-R133)

**Debugging and documentation:**

* Added a helper function `dumpHex` to facilitate debugging of raw TCP payloads, especially for IMU messages, and included documentation referencing the FusionEngine Message Specification. [[1]](diffhunk://#diff-93dde214bd9833a39e067bf618dddd3d5b0946348bc28719eeddd91c5cadf1a5L42-R56) [[2]](diffhunk://#diff-5f74208ca13568d72b4e2ebbd674a8b012b2fcb736e8f820ddf58425e5a583beR21-R27) [[3]](diffhunk://#diff-5f74208ca13568d72b4e2ebbd674a8b012b2fcb736e8f820ddf58425e5a583beR74-R78)

**Repository and minor codebase updates:**

* Changed the fusion engine client repository URL to use the new organization’s GitHub address.
* Minor code cleanups and comment updates to improve maintainability. [[1]](diffhunk://#diff-7ab85002d25210eeddf85d3db1a3fe188f8b50795ad76f19561767aa352af1f7L37-R37) [[2]](diffhunk://#diff-ed9cc5b0e560284c9bb6cb3ceb0336f4d50ae3d10144653716f5cd4cc2797fa0L47)

These changes collectively enhance the driver’s reliability, configurability, and maintainability, especially for IMU and GNSS data processing in ROS environments.