### PR TITLE
Add CODEOWNERS file to define repository maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @airacingtech/maintainers
+
+fusion-engine-driver/** @airacingtech/maintainers


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file, assigning ownership of all files and the `fusion-engine-driver` directory to the `@airacingtech/maintainers` team.