### PR TITLE
Incorrect conversion for angular

### DIFF
--- a/fusion_engine_driver/communication/raw_msgs.hpp
+++ b/fusion_engine_driver/communication/raw_msgs.hpp
@@ -24,11 +24,11 @@ struct RawImu : public sensor_msgs::msg::Imu {
       static_cast<double>(p.accel[2]) / 65536.0;
 
     angular_velocity.x = (p.gyro[0] == INT32_MAX) ? NAN :
-      static_cast<double>(p.gyro[0]) / 65536.0;
+      static_cast<double>(p.gyro[0]) / 1048576.0;
     angular_velocity.y = (p.gyro[1] == INT32_MAX) ? NAN :
-      static_cast<double>(p.gyro[1]) / 65536.0;
+      static_cast<double>(p.gyro[1]) / 1048576.0;
     angular_velocity.z = (p.gyro[2] == INT32_MAX) ? NAN :
-      static_cast<double>(p.gyro[2]) / 65536.0;
+      static_cast<double>(p.gyro[2]) / 1048576.0;
   }
 };
 


### PR DESCRIPTION
This pull request updates the scaling factor for gyroscope data conversion in the `RawImu` struct, ensuring more accurate angular velocity values.

Sensor data conversion:

* Changed the divisor for `gyro` values from `65536.0` to `1048576.0` in the `RawImu` struct within `fusion_engine_driver/communication/raw_msgs.hpp`, improving the precision of the angular velocity calculation.